### PR TITLE
Improve readability of test script

### DIFF
--- a/cvefiles/README.md
+++ b/cvefiles/README.md
@@ -1,7 +1,7 @@
 CVE issues from [mitre.org](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=HDF5)
 
 | CVE\_Issue\_Number | Tested? | File Source | Tool/API | Issue           |
-|--------------------|---------|-------------|----------------------------|
+|--------------------|---------|-------------|----------|-----------------|
 |[CVE-2024-0116-001](official_cve_url)|Y|[cve-2024-0116-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2024-0116-001.h5)| h5dump <file.h5> | heap buffer overflow in H5D__scatter_mem |
 |[CVE-2024-0112-001](official_cve_url)|Y|[cve-2024-0112-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2024-0112-001.h5)| h5dump <file.h5> | heap buffer overflow in H5S__point_deserialize |
 |[CVE-2024-0111-001](official_cve_url)|Y|[cve-2024-0111-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2024-0111-001.h5)| h5dump <file.h5> | heap buffer overflow H5T__conv_struct_opt |

--- a/cvefiles/README.md
+++ b/cvefiles/README.md
@@ -1,105 +1,105 @@
 CVE issues from [mitre.org](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=HDF5)
 
-| CVE\_Issue\_Number | Tested? | File Source |
-|---------|---------|---------|
-|[CVE-2024-0116-001](official_cve_url)|Y|[cve-2024-0116-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2024-0116-001.h5)|
-|[CVE-2024-0112-001](official_cve_url)|Y|[cve-2024-0112-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2024-0112-001.h5)|
-|[CVE-2024-0111-001](official_cve_url)|Y|[cve-2024-0111-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2024-0111-001.h5)|
-|[CVE-2023-1208-002](official_cve_url)|Y|[cve-2023-1208-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1208-002.h5)|
-|[CVE-2023-1208-001](official_cve_url)|Y|[cve-2023-1208-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1208-001.h5)|
-|[CVE-2023-1207-001](official_cve_url)|Y|[cve-2023-1207-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1207-001.h5)|
-|[CVE-2023-1205-001](official_cve_url)|Y|[cve-2023-1205-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1205-001.h5)|
-|[CVE-2023-1202-002](official_cve_url)|Y|[cve-2023-1202-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1202-002.h5)|
-|[CVE-2023-1202-001](official_cve_url)|Y|[cve-2023-1202-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1202-001.h5)|
-|[CVE-2023-1130-001](official_cve_url)|Y|[cve-2023-1130-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1130-001.h5)|
-|[CVE-2023-1125-001](official_cve_url)|Y|[cve-2023-1125-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1125-001.h5)|
-|[CVE-2023-1114-001](official_cve_url)|Y|[cve-2023-1114-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1114-001.h5)|
-|[CVE-2023-1113-002](official_cve_url)|Y|[cve-2023-1113-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1113-002.h5)|
-|[CVE-2023-1113-001](official_cve_url)|Y|[cve-2023-1113-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1113-001.h5)|
-|[CVE-2023-1108-001](official_cve_url)|Y|[cve-2023-1108-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1108-001.h5)|
-|[CVE-2023-1104-004](official_cve_url)|Y|[cve-2023-1104-004.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1104-004.h5)|
-|[CVE-2023-1104-003](official_cve_url)|Y|[cve-2023-1104-003.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1104-003.h5)|
-|[CVE-2023-1104-002](official_cve_url)|Y|[cve-2023-1104-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1104-002.h5)|
-|[CVE-2023-1104-001](official_cve_url)|Y|[cve-2023-1104-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1104-001.h5)|
-|[CVE-2023-1023-001](official_cve_url)|Y|[cve-2023-1023-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1023-001.h5)|
-|[CVE-2023-1019-001](official_cve_url)|Y|[cve-2023-1019-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1019-001.h5)|
-|[CVE-2023-1018-001](official_cve_url)|Y|[cve-2023-1018-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1018-001.h5)|
-|[CVE-2023-1017-002](official_cve_url)|Y|[cve-2023-1017-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1017-002.h5)|
-|[CVE-2023-1017-001](official_cve_url)|Y|[cve-2023-1017-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1017-001.h5)|
-|[CVE-2023-1013-004](official_cve_url)|Y|[cve-2023-1013-004.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1013-004.h5)|
-|[CVE-2023-1013-003](official_cve_url)|Y|[cve-2023-1013-003.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1013-003.h5)|
-|[CVE-2023-1013-002](official_cve_url)|Y|[cve-2023-1013-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1013-002.h5)|
-|[CVE-2023-1013-001](official_cve_url)|Y|[cve-2023-1013-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1013-001.h5)|
-|[CVE-2023-1012-001](official_cve_url)|Y|[cve-2023-1012-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1012-001.h5)|
-|[CVE-2023-1010-001](official_cve_url)|Y|[cve-2023-1010-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1010-001.h5)|
-|[CVE-2023-1009-001](official_cve_url)|Y|[cve-2023-1009-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1009-001.h5)|
-|[CVE-2023-1006-004](official_cve_url)|Y|[cve-2023-1006-004.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1006-004.h5)|
-|[CVE-2023-1006-003](official_cve_url)|Y|[cve-2023-1006-003.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1006-003.h5)|
-|[CVE-2023-1006-002](official_cve_url)|Y|[cve-2023-1006-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1006-002.h5)|
-|[CVE-2023-1006-001](official_cve_url)|Y|[cve-2023-1006-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1006-001.h5)|
-|[CVE-2022-26061](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-26061)|N|pending custom GIF file (3)|
-|[CVE-2022-25972](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25972)|N|pending custom GIF file (3)|
-|[CVE-2022-25942](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25942)|N|pending custom GIF file (3)|
-|[CVE-2021-46244](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46244)|Y|[#1327](https://github.com/HDFGroup/hdf5/issues/1327) [#2242](https://github.com/HDFGroup/hdf5/issues/2242) (hand-crafted file)|
-|[CVE-2021-46243](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46243)|Y|[#1326](https://github.com/HDFGroup/hdf5/issues/1326)|
-|[CVE-2021-46242](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46242)|Y|[#1329](https://github.com/HDFGroup/hdf5/issues/1329)|
-|[CVE-2021-45833](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45833)|Y|[#1313](https://github.com/HDFGroup/hdf5/issues/1313)|
-|[CVE-2021-45832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45832)|N|[#1315](https://github.com/HDFGroup/hdf5/issues/1315) (1)|
-|[CVE-2021-45830](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45830)|Y|[#1314](https://github.com/HDFGroup/hdf5/issues/1314)|
-|[CVE-2021-45829](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45829)|Y|[#1317](https://github.com/HDFGroup/hdf5/issues/1317)|
+| CVE\_Issue\_Number | Tested? | File Source | Tool/API | Issue           |
+|--------------------|---------|-------------|----------------------------|
+|[CVE-2024-0116-001](official_cve_url)|Y|[cve-2024-0116-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2024-0116-001.h5)| h5dump <file.h5> | heap buffer overflow in H5D__scatter_mem |
+|[CVE-2024-0112-001](official_cve_url)|Y|[cve-2024-0112-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2024-0112-001.h5)| h5dump <file.h5> | heap buffer overflow in H5S__point_deserialize |
+|[CVE-2024-0111-001](official_cve_url)|Y|[cve-2024-0111-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2024-0111-001.h5)| h5dump <file.h5> | heap buffer overflow H5T__conv_struct_opt |
+|[CVE-2023-1208-002](official_cve_url)|Y|[cve-2023-1208-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1208-002.h5)| h5repack <file1.h5> <file2.h5> | heap buffer overflow in H5O__mtime_new_encode |
+|[CVE-2023-1208-001](official_cve_url)|Y|[cve-2023-1208-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1208-001.h5)| h5repack <file1.h5> <file2.h5> | heap buffer overflow in H5O__layout_encode |
+|[CVE-2023-1207-001](official_cve_url)|Y|[cve-2023-1207-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1207-001.h5)| unspecified | Heap Buffer Overflow in H5O__dtype_encode_helper |
+|[CVE-2023-1205-001](official_cve_url)|Y|[cve-2023-1205-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1205-001.h5)| h5dump <file.h5> | heap buffer overflow in H5VM_array_fill |
+|[CVE-2023-1202-002](official_cve_url)|Y|[cve-2023-1202-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1202-002.h5)| h5dump <file.h5> | heap buffer overflow in H5T__get_native_type |
+|[CVE-2023-1202-001](official_cve_url)|Y|[cve-2023-1202-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1202-001.h5)| h5dump <file.h5> | heap buffer overflow in H5T__ref_mem_setnull |
+|[CVE-2023-1130-001](official_cve_url)|Y|[cve-2023-1130-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1130-001.h5)| h5dump <file.h5> | heap buffer overflow in H5T_copy_reopen |
+|[CVE-2023-1125-001](official_cve_url)|Y|[cve-2023-1125-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1125-001.h5)| h5dump <file.h5> | heap buffer overflow in H5Z__nbit_decompress_one_byte |
+|[CVE-2023-1114-001](official_cve_url)|Y|[cve-2023-1114-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1114-001.h5)| h5dump <file.h5> | heap buffer overflow in H5HG_read |
+|[CVE-2023-1113-002](official_cve_url)|Y|[cve-2023-1113-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1113-002.h5)| h5dump <file.h5> | heap buffer overflow in H5F_addr_decode_len |
+|[CVE-2023-1113-001](official_cve_url)|Y|[cve-2023-1113-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1113-001.h5)| h5dump <file.h5> | ABORTING/heap buffer overflow caused by the unsafe use of strdup in H5MM_xstrdup |
+|[CVE-2023-1108-001](official_cve_url)|Y|[cve-2023-1108-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1108-001.h5)| h5dump <file.h5> | SEGV/ABORTING/out-of-bounds read operation in H5FL_arr_malloc |
+|[CVE-2023-1104-004](official_cve_url)|Y|[cve-2023-1104-004.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1104-004.h5)| h5repack | SEGV/ABORTING/out-of-bounds read operation in H5T_close_real |
+|[CVE-2023-1104-003](official_cve_url)|Y|[cve-2023-1104-003.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1104-003.h5)| unspecified | ABORTING: heap buffer overflow flaw in the function H5HL__fl_deserialize |
+|[CVE-2023-1104-002](official_cve_url)|Y|[cve-2023-1104-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1104-002.h5)| h5dump | heap buffer overflow in H5HL__fl_deserialize |
+|[CVE-2023-1104-001](official_cve_url)|Y|[cve-2023-1104-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1104-001.h5)| h5dump | DEADLYSIGNAL/stack overflow in the function H5E_printf_stack |
+|[CVE-2023-1023-001](official_cve_url)|Y|[cve-2023-1023-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1023-001.h5)| h5dump | Aborting/heap buffer overflow in H5VM_memcpyvv |
+|[CVE-2023-1019-001](official_cve_url)|Y|[cve-2023-1019-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1019-001.h5)| unspecified | Segmentation fault/stack buffer overflow in H5VM_memcpyvv |
+|[CVE-2023-1018-001](official_cve_url)|Y|[cve-2023-1018-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1018-001.h5)| h5dump | SEGV/ABORTING/memory corruption in H5A__close |
+|[CVE-2023-1017-002](official_cve_url)|Y|[cve-2023-1017-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1017-002.h5)| H5Literate2 | uninitialized value use in H5A__attr_release_table |
+|[CVE-2023-1017-001](official_cve_url)|Y|[cve-2023-1017-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1017-001.h5)| H5Literate2 | attempt to dereference uninitialized values in h5tools_str_sprint |
+|[CVE-2023-1013-004](official_cve_url)|Y|[cve-2023-1013-004.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1013-004.h5)| unspecified | Illegal instruction/stack buffer overflow in H5HG_read |
+|[CVE-2023-1013-003](official_cve_url)|Y|[cve-2023-1013-003.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1013-003.h5)| unspecified | Illegal instruction/buffer overrun in H5Z__filter_fletcher32 |
+|[CVE-2023-1013-002](official_cve_url)|Y|[cve-2023-1013-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1013-002.h5)| unspecified | Illegal instruction/buffer overrun in H5O__linfo_decode |
+|[CVE-2023-1013-001](official_cve_url)|Y|[cve-2023-1013-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1013-001.h5)| unspecified | Illegal instruction/buffer overrun in H5Z__filter_scaleoffset |
+|[CVE-2023-1012-001](official_cve_url)|Y|[cve-2023-1012-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1012-001.h5)| unspecified | Illegal instruction/stack buffer overflow in H5R__decode_heap |
+|[CVE-2023-1010-001](official_cve_url)|Y|[cve-2023-1010-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1010-001.h5)| unspecified | Segmentation fault/stack buffer overflow in H5FL_arr_malloc |
+|[CVE-2023-1009-001](official_cve_url)|Y|[cve-2023-1009-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1009-001.h5)| H5Dread | Segmentation fault/stack buffer overflow in H5FL_arr_malloc|
+|[CVE-2023-1006-004](official_cve_url)|Y|[cve-2023-1006-004.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1006-004.h5)| H5Aiterate2 | heap buffer overflow in H5A__attr_release_table resulting in the corruption of the instruction pointer |
+|[CVE-2023-1006-003](official_cve_url)|Y|[cve-2023-1006-003.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1006-003.h5)| H5Dread | heap buffer overflow in H5T__bit_find resulting in the corruption of the instruction pointer |
+|[CVE-2023-1006-002](official_cve_url)|Y|[cve-2023-1006-002.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1006-002.h5)| unspecified | heap buffer overflow in H5HG_read |
+|[CVE-2023-1006-001](official_cve_url)|Y|[cve-2023-1006-001.h5](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2023-1006-001.h5)| unspecified | heap buffer overflow in H5HG__cache_heap_deserialize |
+|[CVE-2022-26061](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-26061)|N|pending custom GIF file (3)| gif2h5 <file.gif> <file.h5> | |
+|[CVE-2022-25972](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25972)|N|pending custom GIF file (3)| gif2h5 <file.gif> <file.h5> | |
+|[CVE-2022-25942](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25942)|N|pending custom GIF file (3)| gif2h5 <file.gif> <file.h5> | |
+|[CVE-2021-46244](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46244)|Y|[#1327](https://github.com/HDFGroup/hdf5/issues/1327) [#2242](https://github.com/HDFGroup/hdf5/issues/2242) (hand-crafted file)| h5format_convert <file.h5> | |
+|[CVE-2021-46243](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46243)|Y|[#1326](https://github.com/HDFGroup/hdf5/issues/1326)| h5ls <file.h5> | |
+|[CVE-2021-46242](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46242)|Y|[#1329](https://github.com/HDFGroup/hdf5/issues/1329)| h5format_convert <file.h5> | |
+|[CVE-2021-45833](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45833)|Y|[#1313](https://github.com/HDFGroup/hdf5/issues/1313)| h5dump <file.h5> | |
+|[CVE-2021-45832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45832)|N|[#1315](https://github.com/HDFGroup/hdf5/issues/1315) (1)| h5format_convert -n <file.h5> | |
+|[CVE-2021-45830](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45830)|Y|[#1314](https://github.com/HDFGroup/hdf5/issues/1314)| h5format_convert -n <file.h5> | |
+|[CVE-2021-45829](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45829)|Y|[#1317](https://github.com/HDFGroup/hdf5/issues/1317)| h5stat <file.h5> | |
 |[CVE-2021-37501](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37501)|Y|[FILE](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2021-37501.h5)|
 |[CVE-2021-36977](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36977)|Y|[LINK](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31265)|
-|[CVE-2021-31009](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31009)|N|This does not appear to be a specific HDF5 issue (6)|
-|[CVE-2020-10812](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10812)|Y|[h5_nrefs_POC](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2020-10812.h5) (7)|
-|[CVE-2020-10811](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10811)|Y|[h5dump_H5O__layout_decode_POC](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2020-10811.h5) (7)|
-|[CVE-2020-10810](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10810)|Y|[H5AC_unpin_entry_POC](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2020-10810.h5) (7)|
-|[CVE-2020-10809](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10809)|Y|[gif2h5_Decompress_POC](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2020-10809.h5) (7)|
-|[CVE-2019-9152](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9152)|Y|[H5MM_xstrdup_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul8/H5MM_xstrdup_invalid-read-memory-access)|
-|[CVE-2019-9151](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9151)|Y|[H5VM_memcpyvv_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul7/H5VM_memcpyvv_invalid-read-memory-access)|
-|[CVE-2019-8398](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8398)|Y|[H5T_get_size_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul6/H5T_get_size_invalid-read-memory-access)|
-|[CVE-2019-8397](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8397)|Y|[H5T_close_real_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul5/H5T_close_real_invalid-read-memory-access)|
-|[CVE-2019-8396](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8396)|Y|[H5O__pline_decode_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul4/H5O__pline_decode_invalid-read-memory-access)|
-|[CVE-2018-17439](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17439)|Y|[stackoverflow_H5S_extent_get_dims_H5S](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln5/stackoverflow_H5S_extent_get_dims_H5S)|
-|[CVE-2018-17438](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17438)|Y|[SIGFPE_H5D__select_io_H5Dselect](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln4/SIGFPE_H5D__select_io_H5Dselect)|
-|[CVE-2018-17437](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17437)|Y|[memleak_H5O_dtype_decode_helper_H5Odtype](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln5/memleak_H5O_dtype_decode_helper_H5Odtype)|
-|[CVE-2018-17436](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17436)|Y|[ReadCode_decompress_memoryAccess](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln8/ReadCode_decompress_memoryAccess)|
-|[CVE-2018-17435](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17435)|Y|[Heap_Overflow_H5O_attr_decode](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln7/Heap_Overflow_H5O_attr_decode)|
-|[CVE-2018-17434](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17434)|Y|[SIGFPE_apply_filters_h5repack_filters](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln4/SIGFPE_apply_filters_h5repack_filters)|
-|[CVE-2018-17433](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17433)|Y|[HeapOverflow_ReadGifImageDesc](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln8/HeapOverflow_ReadGifImageDesc)|
-|[CVE-2018-17432](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17432)|Y|[Null_Pointer_H5O_sdspace_encode](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln6/Null_Pointer_H5O_sdspace_encode)|
-|[CVE-2018-17237](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17237)|Y|[H5D__chunk_set_info_real_div_by_zero](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/H5D__chunk_set_info_real_div_by_zero)|
-|[CVE-2018-17234](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17234)|Y|[H5O__chunk_deserialize_memory_leak](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln3/H5O__chunk_deserialize_memory_leak)|
-|[CVE-2018-17233](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17233)|Y|[H5D__create_chunk_file_map_hyper_div_zero](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln2/H5D__create_chunk_file_map_hyper_div_zero)|
-|[CVE-2018-16438](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16438)|Y|[H5L_extern_query@H5Lexternal.c:498-10___out-of-bounds-read](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/h5stat/H5L_extern_query%40H5Lexternal.c%3A498-10___out-of-bounds-read)|
-|[CVE-2018-15672](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15672)|Y|duplicate of CVE-2018-11207 (2)|
-|[CVE-2018-15671](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15671)|Y|[stackoverflow_H5P__get_cb](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/stackoverflow_H5P__get_cb)|
-|[CVE-2018-14460](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14460)|Y|[H5O_sdspace_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5O_sdspace_decode-heap-buffer-overflow)|
-|[CVE-2018-14035](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14035)|Y|[H5VM_memcpyvv-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5VM_memcpyvv-heap-buffer-overflow)|
-|[CVE-2018-14034](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14034)|Y|[H5O_pline_reset-out-of-bound-read](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5O_pline_reset-out-of-bound-read)|
-|[CVE-2018-14033](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14033)|Y|[H5O_layout_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5O_layout_decode-heap-buffer-overflow)|
-|[CVE-2018-14031](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14031)|Y|[H5T_copy-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5T_copy-heap-buffer-overflow)|
-|[CVE-2018-13876](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13876)|Y|[H5FD_sec2_read-stack-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5FD_sec2_read-stack-buffer-overflow)|
-|[CVE-2018-13875](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13875)|Y|[H5VM_memcpyvv-OUT_OF_BOUND_READ](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5VM_memcpyvv-OUT_OF_BOUND_READ)|
-|[CVE-2018-13874](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13874)|Y|[H5FD_sec2_read-stack-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5FD_sec2_read-stack-buffer-overflow)|
-|[CVE-2018-13873](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13873)|Y|[H5O_chunk_deserialize-global-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5O_chunk_deserialize-global-buffer-overflow)|
-|[CVE-2018-13872](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13872)|Y|[H5G_ent_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5G_ent_decode-heap-buffer-overflow)|
-|[CVE-2018-13871](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13871)|Y|[H5FL_blk_malloc-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5FL_blk_malloc-heap-buffer-overflow)|
-|[CVE-2018-13870](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13870)|Y|[H5O_link_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5O_link_decode-heap-buffer-overflow)|
-|[CVE-2018-13869](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13869)|Y|[H5O_link_decode-memcpy-param-overlap](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5O_link_decode-memcpy-param-overlap)|
-|[CVE-2018-13868](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13868)|Y|[H5O_fill_old_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5O_fill_old_decode-heap-buffer-overflow)|
-|[CVE-2018-13867](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13867)|Y|[H5F__accum_read-Out_Of_Bound_Read](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5F__accum_read-Out_Of_Bound_Read)|
-|[CVE-2018-13866](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13866)|Y|[H5F_addr_decode_len-stack-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5F_addr_decode_len-stack-buffer-overflow)|
-|[CVE-2018-11207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11207)|Y|2 files [divbyzero__h5d_chunk_poc](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/DivByZero__H5D_chunk_POC) [H5D__chunk_init-H5Dchunk.c_1022-div_by_zero](https://github.com/Twi1ight/fuzzing-pocs/blob/master/hdf5/H5D__chunk_init-H5Dchunk.c_1022-div_by_zero)|
-|[CVE-2018-11206](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11206)|Y|2 files [H5O_fill_new_decode-H5Ofill.c_233-oob_read/H5O_fill_old_decode-H5Ofill.c_337-oob_read](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)|
-|[CVE-2018-11205](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11205)|Y|[H5VM_memcpyvv-H5VM.c_1626-oob_read](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)|
-|[CVE-2018-11204](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11204)|Y|[H5O__chunk_deserialize-H5Ocache.c_1566-null_point_dereference](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)|
-|[CVE-2018-11203](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11203)|Y|[H5D__btree_decode_key-H5Dbtree.c_697-div_by_zero](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)|
-|[CVE-2018-11202](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11202)|Y|[H5S_hyper_make_spans-H5Shyper.c_6139-null_pointer_dereference](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)|
-|[CVE-2017-17509](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17509)|Y|[5-hdf5-heap-overflow-H5G__ent_decode_vec](https://github.com/xiaoqx/pocs/blob/master/hdf5)|
-|[CVE-2017-17508](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17508)|Y|[1-hdf5-divbyzero-H5T_set_loc](https://github.com/xiaoqx/pocs/tree/master/hdf5)|
-|[CVE-2017-17507](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17507)|Y|[3-hdf5-outbound-read-H5T_conv_struct_opt](https://github.com/xiaoqx/pocs/tree/master/hdf5)|
-|[CVE-2017-17506](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17506)|Y|[4-hdf5-outbound-read-H5Opline_pline_decode](https://github.com/xiaoqx/pocs/tree/master/hdf5)|
-|[CVE-2017-17505](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17505)|Y|[2-hdf5-null-pointer-H5O_pline_decode](https://github.com/xiaoqx/pocs/tree/master/hdf5)|
+|[CVE-2021-31009](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31009)|N|This does not appear to be a specific HDF5 issue (6)| | |
+|[CVE-2020-10812](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10812)|Y|[h5_nrefs_POC](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2020-10812.h5) (7)| h5debug <file.h5> | |
+|[CVE-2020-10811](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10811)|Y|[h5dump_H5O__layout_decode_POC](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2020-10811.h5) (7)| h5dump -r -d BAG_root/metadata <file.h5> | |
+|[CVE-2020-10810](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10810)|Y|[H5AC_unpin_entry_POC](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2020-10810.h5) (7)| h5clear -s -m <file.h5> | |
+|[CVE-2020-10809](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10809)|Y|[gif2h5_Decompress_POC](https://github.com/HDFGroup/cve_hdf5/blob/main/cvefiles/cve-2020-10809.h5) (7)| gif2h5 <file.gif> <file.h5> | |
+|[CVE-2019-9152](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9152)|Y|[H5MM_xstrdup_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul8/H5MM_xstrdup_invalid-read-memory-access)| h5dump <file.h5> | |
+|[CVE-2019-9151](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9151)|Y|[H5VM_memcpyvv_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul7/H5VM_memcpyvv_invalid-read-memory-access)| h5repack <file1.h5> <file2.h5> | |
+|[CVE-2019-8398](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8398)|Y|[H5T_get_size_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul6/H5T_get_size_invalid-read-memory-access)| h5repack <file1.h5> <file2.h5> | |
+|[CVE-2019-8397](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8397)|Y|[H5T_close_real_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul5/H5T_close_real_invalid-read-memory-access)| h5repack <file1.h5> <file2.h5> | |
+|[CVE-2019-8396](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8396)|Y|[H5O__pline_decode_invalid-read-memory-access](https://github.com/magicSwordsMan/PAAFS/blob/master/vul4/H5O__pline_decode_invalid-read-memory-access)| h5dump <file.h5> | |
+|[CVE-2018-17439](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17439)|Y|[stackoverflow_H5S_extent_get_dims_H5S](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln5/stackoverflow_H5S_extent_get_dims_H5S)| gif2h5 <file.gif> <file.h5> | |
+|[CVE-2018-17438](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17438)|Y|[SIGFPE_H5D__select_io_H5Dselect](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln4/SIGFPE_H5D__select_io_H5Dselect)| gif2h5 <file.gif> <file.h5> | |
+|[CVE-2018-17437](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17437)|Y|[memleak_H5O_dtype_decode_helper_H5Odtype](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln5/memleak_H5O_dtype_decode_helper_H5Odtype)| h52gif <file.h5> <file.gif> | |
+|[CVE-2018-17436](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17436)|Y|[ReadCode_decompress_memoryAccess](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln8/ReadCode_decompress_memoryAccess)| gif2h5 <file.gif> <file.h5> | |
+|[CVE-2018-17435](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17435)|Y|[Heap_Overflow_H5O_attr_decode](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln7/Heap_Overflow_H5O_attr_decode)| h52gif <file.gif> image1.gif -i image | |
+|[CVE-2018-17434](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17434)|Y|[SIGFPE_apply_filters_h5repack_filters](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln4/SIGFPE_apply_filters_h5repack_filters)| h5repack -f GZIP=8 -l dset1:CHUNK=5x6 <file1.h5> <file2.h5> | |
+|[CVE-2018-17433](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17433)|Y|[HeapOverflow_ReadGifImageDesc](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln8/HeapOverflow_ReadGifImageDesc)| gif2h5 <file.gif> <file.h5> | |
+|[CVE-2018-17432](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17432)|Y|[Null_Pointer_H5O_sdspace_encode](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln6/Null_Pointer_H5O_sdspace_encode)| h5repack <file1.h5> <file2.h5> | |
+|[CVE-2018-17237](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17237)|Y|[H5D__chunk_set_info_real_div_by_zero](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/H5D__chunk_set_info_real_div_by_zero)| h5dump <file.h5> | |
+|[CVE-2018-17234](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17234)|Y|[H5O__chunk_deserialize_memory_leak](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln3/H5O__chunk_deserialize_memory_leak)| h5dump <file.h5> | |
+|[CVE-2018-17233](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17233)|Y|[H5D__create_chunk_file_map_hyper_div_zero](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/vuln2/H5D__create_chunk_file_map_hyper_div_zero)| h5dump -r -d BAG_root/metadata <file.h5> | |
+|[CVE-2018-16438](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16438)|Y|[H5L_extern_query@H5Lexternal.c:498-10___out-of-bounds-read](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/h5stat/H5L_extern_query%40H5Lexternal.c%3A498-10___out-of-bounds-read)| h5dump <file.h5> | |
+|[CVE-2018-15672](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15672)|Y|duplicate of CVE-2018-11207 (2)| h5dump <file.h5> | |
+|[CVE-2018-15671](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15671)|Y|[stackoverflow_H5P__get_cb](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/stackoverflow_H5P__get_cb)| h5dump <file.h5> | |
+|[CVE-2018-14460](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14460)|Y|[H5O_sdspace_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5O_sdspace_decode-heap-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-14035](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14035)|Y|[H5VM_memcpyvv-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5VM_memcpyvv-heap-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-14034](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14034)|Y|[H5O_pline_reset-out-of-bound-read](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5O_pline_reset-out-of-bound-read)| h5dump <file.h5> | |
+|[CVE-2018-14033](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14033)|Y|[H5O_layout_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5O_layout_decode-heap-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-14031](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14031)|Y|[H5T_copy-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln2/H5T_copy-heap-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-13876](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13876)|Y|[H5FD_sec2_read-stack-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5FD_sec2_read-stack-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-13875](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13875)|Y|[H5VM_memcpyvv-OUT_OF_BOUND_READ](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5VM_memcpyvv-OUT_OF_BOUND_READ)| h5dump <file.h5> | |
+|[CVE-2018-13874](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13874)|Y|[H5FD_sec2_read-stack-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5FD_sec2_read-stack-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-13873](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13873)|Y|[H5O_chunk_deserialize-global-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5O_chunk_deserialize-global-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-13872](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13872)|Y|[H5G_ent_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5G_ent_decode-heap-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-13871](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13871)|Y|[H5FL_blk_malloc-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5FL_blk_malloc-heap-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-13870](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13870)|Y|[H5O_link_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5O_link_decode-heap-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-13869](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13869)|Y|[H5O_link_decode-memcpy-param-overlap](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5O_link_decode-memcpy-param-overlap)| h5dump <file.h5> | |
+|[CVE-2018-13868](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13868)|Y|[H5O_fill_old_decode-heap-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5O_fill_old_decode-heap-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-13867](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13867)|Y|[H5F__accum_read-Out_Of_Bound_Read](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5F__accum_read-Out_Of_Bound_Read)| h5dump <file.h5> | |
+|[CVE-2018-13866](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-13866)|Y|[H5F_addr_decode_len-stack-buffer-overflow](https://github.com/TeamSeri0us/pocs/blob/master/hdf5/vuln/H5F_addr_decode_len-stack-buffer-overflow)| h5dump <file.h5> | |
+|[CVE-2018-11207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11207)|Y|2 files [divbyzero__h5d_chunk_poc](https://github.com/SegfaultMasters/covering360/blob/master/HDF5/DivByZero__H5D_chunk_POC) [H5D__chunk_init-H5Dchunk.c_1022-div_by_zero](https://github.com/Twi1ight/fuzzing-pocs/blob/master/hdf5/H5D__chunk_init-H5Dchunk.c_1022-div_by_zero)| h5stat -A -T -G -D -S <file.h5> | |
+|[CVE-2018-11206](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11206)|Y|2 files [H5O_fill_new_decode-H5Ofill.c_233-oob_read/H5O_fill_old_decode-H5Ofill.c_337-oob_read](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)| h5dump <file.h5> | |
+|[CVE-2018-11205](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11205)|Y|[H5VM_memcpyvv-H5VM.c_1626-oob_read](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)| h5dump <file.h5> | |
+|[CVE-2018-11204](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11204)|Y|[H5O__chunk_deserialize-H5Ocache.c_1566-null_point_dereference](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)| h5dump <file.h5> | |
+|[CVE-2018-11203](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11203)|Y|[H5D__btree_decode_key-H5Dbtree.c_697-div_by_zero](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)| h5dump <file.h5> | |
+|[CVE-2018-11202](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11202)|Y|[H5S_hyper_make_spans-H5Shyper.c_6139-null_pointer_dereference](https://github.com/Twi1ight/fuzzing-pocs/tree/master/hdf5)| h5dump <file.h5> | |
+|[CVE-2017-17509](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17509)|Y|[5-hdf5-heap-overflow-H5G__ent_decode_vec](https://github.com/xiaoqx/pocs/blob/master/hdf5)| h5dump <file.h5> | |
+|[CVE-2017-17508](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17508)|Y|[1-hdf5-divbyzero-H5T_set_loc](https://github.com/xiaoqx/pocs/tree/master/hdf5)| h5dump <file.h5> | |
+|[CVE-2017-17507](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17507)|Y|[3-hdf5-outbound-read-H5T_conv_struct_opt](https://github.com/xiaoqx/pocs/tree/master/hdf5)| h5dump <file.h5> | |
+|[CVE-2017-17506](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17506)|Y|[4-hdf5-outbound-read-H5Opline_pline_decode](https://github.com/xiaoqx/pocs/tree/master/hdf5)| h5dump <file.h5> | |
+|[CVE-2017-17505](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17505)|Y|[2-hdf5-null-pointer-H5O_pline_decode](https://github.com/xiaoqx/pocs/tree/master/hdf5)| h5dump <file.h5> | |
 |[CVE-2016-4333](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4333)|N|Talos - no poc file (4)|
 |[CVE-2016-4332](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4332)|N|Talos - no poc file (4)|
 |[CVE-2016-4331](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4331)|N|Talos - no poc file (4)|

--- a/test_hdf5_cve.sh
+++ b/test_hdf5_cve.sh
@@ -80,82 +80,13 @@ H5STAT=$bindir/h5stat
 # Location of CVE files
 CVE_H5_FILES_DIR=cvefiles
 
-# How are the CVE issues tested?
-# CVE-2017-17505    h5dump <file.h5>
-# CVE-2017-17506    h5dump <file.h5>
-# CVE-2017-17507    h5dump <file.h5>
-# CVE-2017-17508    h5dump <file.h5>
-# CVE-2017-17509    h5dump <file.h5>
-# CVE-2018-11202    h5dump <file.h5>
-# CVE-2018-11203    h5dump <file.h5>
-# CVE-2018-11204    h5dump <file.h5>
-# CVE-2018-11205    h5dump <file.h5>
-# CVE-2018-11206    h5dump <file.h5>
-# CVE-2018-11207    h5stat -A -T -G -D -S <file.h5>
-# CVE-2018-13866    h5dump <file.h5>
-# CVE-2018-13867    h5dump <file.h5>
-# CVE-2018-13868    h5dump <file.h5>
-# CVE-2018-13869    h5dump <file.h5>
-# CVE-2018-13870    h5dump <file.h5>
-# CVE-2018-13871    h5dump <file.h5>
-# CVE-2018-13872    h5dump <file.h5>
-# CVE-2018-13873    h5dump <file.h5>
-# CVE-2018-13874    h5dump <file.h5>
-# CVE-2018-13875    h5dump <file.h5>
-# CVE-2018-13876    h5dump <file.h5>
-# CVE-2018-14031    h5dump <file.h5>
-# CVE-2018-14033    h5dump <file.h5>
-# CVE-2018-14034    h5dump <file.h5>
-# CVE-2018-14035    h5dump <file.h5>
-# CVE-2018-14460    h5dump <file.h5>
-# CVE-2018-15671    h5dump <file.h5>
-# CVE-2018-15672    h5dump <file.h5>
-# CVE-2018-16438    h5dump <file.h5>
-# CVE-2018-17233    h5dump -r -d BAG_root/metadata <file.h5>
-# CVE-2018-17234    h5dump <file.h5>
-# CVE-2018-17237    h5dump <file.h5>
-# CVE-2018-17432    h5repack <file1.h5> <file2.h5>
-# CVE-2018-17433    gif2h5 <file.gif> <file.h5>
-# CVE-2018-17434    h5repack -f GZIP=8 -l dset1:CHUNK=5x6 <file1.h5> <file2.h5>
-# CVE-2018-17435    h52gif <file.gif> image1.gif -i image
-# CVE-2018-17436    gif2h5 <file.gif> <file.h5>
-# CVE-2018-17437    h52gif <file.h5> <file.gif>
-# CVE-2018-17438    gif2h5 <file.gif> <file.h5>
-# CVE-2018-17439    gif2h5 <file.gif> <file.h5>
-# CVE-2019-8396     h5dump <file.h5>
-# CVE-2019-8397     h5repack <file1.h5> <file2.h5>
-# CVE-2019-8398     h5repack <file1.h5> <file2.h5>
-# CVE-2019-9151     h5repack <file1.h5> <file2.h5>
-# CVE-2019-9152     h5dump <file.h5>
-# CVE-2020-10809    gif2h5 <file.gif> <file.h5>
-# CVE-2020-10810    h5clear -s -m <file.h5>
-# CVE-2020-10811    h5dump -r -d BAG_root/metadata <file.h5>
-# CVE-2020-10812    h5debug <file.h5>
-# CVE-2021-31009    Not an HDF5-specific issue
-# CVE-2021-36977    libFuzzer?
-# CVE-2021-37501    h5dump <file.h5>
-# CVE-2021-45829    h5stat <file.h5>
-# CVE-2021-45830    h5format_convert -n <file.h5>
-# CVE-2021-45832    h5format_convert -n <file.h5>
-# CVE-2021-45833    h5dump <file.h5>
-# CVE-2021-46242    h5format_convert <file.h5>
-# CVE-2021-46243    h5ls <file.h5>
-# CVE-2021-46244    h5format_convert <file.h5>
-# CVE-2022-25942    gif2h5 <file.gif> <file.h5>
-# CVE-2022-25972    gif2h5 <file.gif> <file.h5>
-# CVE-2022-26061    gif2h5 <file.gif> <file.h5>
-
-GIF2H5_TEST_FILES="
-cve-2018-17433.h5
-cve-2018-17436.h5
-cve-2018-17438.h5
-cve-2018-17439.h5
-cve-2020-10809.h5
-cve-2022-25942.h5
-cve-2022-25972.h5
-cve-2022-26061.h5
-"
-
+# All of the CVE files are tested against the following tools:
+#    h5dump, h5debug, h5ls, h5repack, and h5stat
+# without any options.
+#
+# Then a number of the CVE files are then tested against the tools and
+# options as specified in the CVE reports.  See the README file in the
+# directory cvefiles/ for details.
 CVE_TEST_FILES="
 cve-2016-4330.h5
 cve-2016-4331.h5
@@ -257,6 +188,17 @@ cve-2023-1208-002.h5
 cve-2024-0111-001.h5
 cve-2024-0112-001.h5
 cve-2024-0116-001.h5
+"
+
+GIF2H5_TEST_FILES="
+cve-2018-17433.h5
+cve-2018-17436.h5
+cve-2018-17438.h5
+cve-2018-17439.h5
+cve-2020-10809.h5
+cve-2022-25942.h5
+cve-2022-25972.h5
+cve-2022-26061.h5
 "
 
 # Checks return value and display appropriate message


### PR DESCRIPTION
Moved the big comment into the table in the README file as it can potentially grow very long.